### PR TITLE
"Fix" stars_per_day metric

### DIFF
--- a/methods.js
+++ b/methods.js
@@ -40,7 +40,7 @@ const rebuildCache = (json) => {
   const active_members = members.filter((m) => m.stars > 0);
   const stars = members.reduce((sum, { stars }) => sum + stars, 0);
   const stars_per_active_member = stars / active_members.length;
-  const stars_per_day = stars / new Date().getDate();
+  const stars_per_day = stars / (new Date().getDate() - 1); // -1 as good morning message happens as new day is active
 
   cache.data = json;
   cache.members = members.length;


### PR DESCRIPTION
This PR changes stars_per_day to use yesterday's date instead for the good morning message.

Or else it'll bring the stars for the current day which will be 0 (as the message happens just before the puzzle is released) and make the average less than it is supposed to be. This makes the trajectory calc more fair (still optimistic though).